### PR TITLE
Added support for Sublime Text 2 packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 ```puppet
 include sublime_text_2
+sublime_text_2::package { 'Emmet':
+  source => 'sergeche/emmet-sublime'
+}
 ```
 
 ## Required Puppet Modules

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,13 @@
+# Internal: Prepare your system for Sublime Text 2 packages.
+#
+# Examples
+#
+#   include sublime_text_2::config
+class sublime_text_2::config {
+  $dir        = "/Users/${::luser}/Library/Application Support/Sublime Text 2"
+  $packagedir = "${dir}/Packages"
+
+  file { [$dir, $packagedir]:
+    ensure => directory
+  }
+}

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,0 +1,17 @@
+# Public: Install a Sublime Text 2 package.
+#
+# namevar - The name of the package.
+# source  - The location of the git repository containing the package.
+#
+# Examples
+#
+#   sublime_text_2::plugin { 'Emmet':
+#     source => 'sergeche/emmet-sublime'
+#   }
+define sublime_text_2::package($source) {
+  require sublime_text_2::config
+
+  repository { "${sublime_text_2::config::packagedir}/${name}":
+    source => $source
+  }
+}

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -5,7 +5,7 @@
 #
 # Examples
 #
-#   sublime_text_2::plugin { 'Emmet':
+#   sublime_text_2::package { 'Emmet':
 #     source => 'sergeche/emmet-sublime'
 #   }
 define sublime_text_2::package($source) {

--- a/spec/classes/sublime_text_2__config_spec.rb
+++ b/spec/classes/sublime_text_2__config_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'sublime_text_2::config' do
+  let(:facts) { {:luser => 'testuser'} }
+
+  let(:sublimedir) { "/Users/#{facts[:luser]}/Library/Application Support/Sublime Text 2" }
+  let(:packagedir) { "#{sublimedir}/Packages" }
+
+  it { should contain_file(sublimedir).with_ensure('directory') }
+  it { should contain_file(packagedir).with_ensure('directory') }
+end

--- a/spec/defines/sublime_text_2__package_spec.rb
+++ b/spec/defines/sublime_text_2__package_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'sublime_text_2::package' do
+  let(:title) { 'test' }
+  let(:params) { {:source => 'https://github.com/foo/bar'} }
+  let(:facts) do
+    {
+      :luser      => 'testuser',
+      :boxen_home => '/opt/boxen',
+    }
+  end
+  let(:package_dir) { "/Users/#{facts[:luser]}/Library/Application Support/Sublime Text 2/Packages" }
+
+  # FIXME - rspec-puppet should properly stub facts instead of this hack.
+  before :each do
+    facts.each do |fact, val|
+      Facter.add(fact.to_s) do
+        setcode { val }
+      end
+    end
+  end
+
+  it { should include_class('sublime_text_2::config') }
+
+  it do
+    should contain_repository("#{package_dir}/#{title}").with({
+      :source => params[:source],
+    })
+  end
+end

--- a/spec/fixtures/Puppetfile
+++ b/spec/fixtures/Puppetfile
@@ -1,0 +1,1 @@
+mod 'boxen', '1.2.0', :github_tarball => 'boxen/puppet-boxen'


### PR DESCRIPTION
Hey, 

I added support for Sublime Text 2 packages, so that you can do something like this:

```
include sublime_text_2
sublime_text_2::package { 'Emmet':
  source => 'sergeche/emmet-sublime'
}
```

There is one problem though. In case one has already installed the package using Package Control, one will get an error like below:

```
Error: Execution of '/opt/boxen/homebrew/bin/git clone --recurse-submodules -c credential.helper=/opt/boxen/bin/boxen-git-credential https://github.com/sergeche/emmet-sublime /Users/janne/Library/Application\ Support/Sublime\ Text\ 2/Packages/Emmet' returned 128: fatal: destination path '/Users/janne/Library/Application Support/Sublime Text 2/Packages/Emmet' already exists and is not an empty directory.
```

Any suggestions how to handle this? 
