### PR TITLE
Added Sublime Text 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
-# Sublime Text 2 Puppet Module for Boxen
+# Sublime Text Puppet Module for Boxen
 
 [![Build Status](https://travis-ci.org/boxen/puppet-sublime_text_2.png?branch=master)](https://travis-ci.org/boxen/puppet-sublime_text_2)
 
-Install [Sublime Text 2](http://www.sublimetext.com//), a text-editor/IDE for Mac
+Install [Sublime Text 3](http://www.sublimetext.com/3) or [Sublime Text 2](http://www.sublimetext.com/), a text-editor/IDE for Mac
 
 ## Usage
 
 ```puppet
+# For the latest build of v3
+include sublime_text
+sublime_text::package { 'Emmet':
+  source => 'sergeche/emmet-sublime'
+}
+
+# For the latest version of v2
 include sublime_text_2
 sublime_text_2::package { 'Emmet':
   source => 'sergeche/emmet-sublime'

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ sublime_text::package { 'Emmet':
 }
 
 # For the latest version of v2
-include sublime_text_2
-sublime_text_2::package { 'Emmet':
+include sublime_text::v2
+sublime_text::v2::package { 'Emmet':
   source => 'sergeche/emmet-sublime'
 }
 ```

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,13 +1,12 @@
-# Internal: Prepare your system for Sublime Text 2 packages.
+# Internal: Prepare your system for Sublime Text packages.
 #
 # Examples
 #
-#   include sublime_text_2::config
-class sublime_text_2::config {
-  $dir        = "/Users/${::luser}/Library/Application Support/Sublime Text 2"
+#   include sublime_text::config
+class sublime_text::config {
+  $dir = "/Users/${::luser}/Library/Application Support/Sublime Text"
   $packagedir = "${dir}/Packages"
 
   file { [$dir, $packagedir]:
     ensure => directory
-  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,18 +1,19 @@
-# Install Sublime Text 2 into /Applications
+# Install Sublime Text into /Applications
 #
 # Usage:
 #
-#     include sublime_text_2
-class sublime_text_2 {
-  package { 'SublimeText2':
+#     include sublime_text
+class sublime_text($build = '3059') {
+  package { 'Sublime Text':
     provider => 'appdmg',
-    source   => 'http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%202.0.2.dmg';
+    source   => "http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%20Build%20${build}.dmg";
   }
 
   file { "${boxen::config::bindir}/subl":
     ensure  => link,
-    target  => '/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl',
+    target  => '/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl',
     mode    => '0755',
-    require => Package['SublimeText2'],
+    require => Package['Sublime Text'],
   }
 }
+

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,17 +1,17 @@
-# Public: Install a Sublime Text 2 package.
+# Public: Install a Sublime Text package.
 #
 # namevar - The name of the package.
 # source  - The location of the git repository containing the package.
 #
 # Examples
 #
-#   sublime_text_2::package { 'Emmet':
+#   sublime_text::package { 'Emmet':
 #     source => 'sergeche/emmet-sublime'
 #   }
-define sublime_text_2::package($source) {
-  require sublime_text_2::config
+define sublime_text::package($source) {
+  require sublime_text::config
 
-  repository { "${sublime_text_2::config::packagedir}/${name}":
+  repository { "${sublime_text::config::packagedir}/${name}":
     source => $source
   }
 }

--- a/manifests/v2.pp
+++ b/manifests/v2.pp
@@ -1,0 +1,19 @@
+# Install Sublime Text 2 into /Applications
+#
+# Usage:
+#
+#     include sublime_text::v2
+class sublime_text::v2 ($version = '2.0.2') {
+  package { 'Sublime Text 2':
+    provider => 'appdmg',
+    source   => "http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%20${version}.dmg";
+  }
+
+  file { "${boxen::config::bindir}/subl2":
+    ensure  => link,
+    target  => '/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl',
+    mode    => '0755',
+    require => Package['Sublime Text 2'],
+  }
+}
+

--- a/manifests/v2_config.pp
+++ b/manifests/v2_config.pp
@@ -1,0 +1,13 @@
+# Internal: Prepare your system for Sublime Text 2 packages.
+#
+# Examples
+#
+#   include sublime_text::v2::config
+class sublime_text::v2::config {
+  $dir        = "/Users/${::luser}/Library/Application Support/Sublime Text 2"
+  $packagedir = "${dir}/Packages"
+
+  file { [$dir, $packagedir]:
+    ensure => directory
+  }
+}

--- a/manifests/v2_package.pp
+++ b/manifests/v2_package.pp
@@ -1,0 +1,17 @@
+# Public: Install a Sublime Text 2 package.
+#
+# namevar - The name of the package.
+# source  - The location of the git repository containing the package.
+#
+# Examples
+#
+#   sublime_text::v2::package { 'Emmet':
+#     source => 'sergeche/emmet-sublime'
+#   }
+define sublime_text::v2::package($source) {
+  require sublime_text::v2::config
+
+  repository { "${sublime_text_2::config::packagedir}/${name}":
+    source => $source
+  }
+}

--- a/spec/classes/sublime_text-v2__config_spec.rb
+++ b/spec/classes/sublime_text-v2__config_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'sublime_text_2::config' do
+describe 'sublime_text::v2::config' do
   let(:facts) { {:luser => 'testuser'} }
 
   let(:sublimedir) { "/Users/#{facts[:luser]}/Library/Application Support/Sublime Text 2" }

--- a/spec/classes/sublime_text-v2_spec.rb
+++ b/spec/classes/sublime_text-v2_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe 'sublime_text_2' do
+describe 'sublime_text::v2' do
   it do
-    should contain_package('SublimeText2').with({
+    should contain_package('Sublime Text 2').with({
       :provider => 'appdmg',
       :source   => 'http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%202.0.2.dmg'
     })

--- a/spec/classes/sublime_text__config_spec.rb
+++ b/spec/classes/sublime_text__config_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'sublime_text::config' do
+  let(:facts) { {:luser => 'testuser'} }
+
+  let(:sublimedir) { "/Users/#{facts[:luser]}/Library/Application Support/Sublime Text" }
+  let(:packagedir) { "#{sublimedir}/Packages" }
+
+  it { should contain_file(sublimedir).with_ensure('directory') }
+  it { should contain_file(packagedir).with_ensure('directory') }
+end

--- a/spec/classes/sublime_text_spec.rb
+++ b/spec/classes/sublime_text_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'sublime_text' do
+  it do
+    should contain_package('Sublime Text').with({
+      :provider => 'appdmg',
+      :source   => 'http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%20Build%203059.dmg'
+    })
+  end
+end

--- a/spec/defines/sublime_text-v2__package_spec.rb
+++ b/spec/defines/sublime_text-v2__package_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe "sublime_text::v2::package" do
+  let(:title) { 'test' }
+  let(:params) { {:source => 'https://github.com/foo/bar'} }
+  let(:facts) do
+    {
+      :luser      => 'testuser',
+      :boxen_home => '/opt/boxen',
+    }
+  end
+  let(:package_dir) { "/Users/#{facts[:luser]}/Library/Application Support/Sublime Text 2/Packages" }
+
+  # FIXME - rspec-puppet should properly stub facts instead of this hack.
+  before :each do
+    facts.each do |fact, val|
+      Facter.add(fact.to_s) do
+        setcode { val }
+      end
+    end
+  end
+
+  it { should include_class('sublime_text::v2::config') }
+
+  it do
+    should contain_repository("#{package_dir}/#{title}").with({
+      :source => params[:source],
+    })
+  end
+end
+

--- a/spec/defines/sublime_text__package_spec.rb
+++ b/spec/defines/sublime_text__package_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'sublime_text_2::package' do
+describe "sublime_text::v2::package" do
   let(:title) { 'test' }
   let(:params) { {:source => 'https://github.com/foo/bar'} }
   let(:facts) do
@@ -9,7 +9,7 @@ describe 'sublime_text_2::package' do
       :boxen_home => '/opt/boxen',
     }
   end
-  let(:package_dir) { "/Users/#{facts[:luser]}/Library/Application Support/Sublime Text 2/Packages" }
+  let(:package_dir) { "/Users/#{facts[:luser]}/Library/Application Support/Sublime Text/Packages" }
 
   # FIXME - rspec-puppet should properly stub facts instead of this hack.
   before :each do
@@ -20,7 +20,7 @@ describe 'sublime_text_2::package' do
     end
   end
 
-  it { should include_class('sublime_text_2::config') }
+  it { should include_class('sublime_text::config') }
 
   it do
     should contain_repository("#{package_dir}/#{title}").with({

--- a/spec/fixtures/Puppetfile
+++ b/spec/fixtures/Puppetfile
@@ -1,2 +1,2 @@
 mod 'boxen', '3.6.0', :github_tarball => 'boxen/puppet-boxen'
-mod 'stdlib', '4.1.0', :github_tarball => 'boxen/puppet-boxen'
+mod 'stdlib', '4.1.0', :github_tarball => 'puppetlabs/puppetlabs-stdlib'

--- a/spec/fixtures/Puppetfile
+++ b/spec/fixtures/Puppetfile
@@ -1,1 +1,2 @@
-mod 'boxen', '1.2.0', :github_tarball => 'boxen/puppet-boxen'
+mod 'boxen', '3.6.0', :github_tarball => 'boxen/puppet-boxen'
+mod 'stdlib', '4.1.0', :github_tarball => 'boxen/puppet-boxen'


### PR DESCRIPTION
Alright so I know there has been some discussion about how to [handle this](https://github.com/boxen/our-boxen/issues/377).

My PR only works if the repo name is changed to `puppet-sublime_text`

``` puppet
# ST3
include sublime_text

# ST2
include sublime_text::v2
```

I'm open to suggestions on how to change this.

Another solution I can think of is leaving this repo so that we don't break dependencies, and then on the README just forward them to the `puppet-sublime_text`.
